### PR TITLE
Reconnects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "tcpocket",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "5.0.2",
+      "version": "5.0.3",
       "license": "MIT",
       "dependencies": {
         "ndjson-fe": "^1.2.7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tcpocket",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "description": "[![Build Status](https://travis-ci.org/markwylde/tcpocket.svg?branch=master)](https://travis-ci.org/markwylde/tcpocket) [![David DM](https://david-dm.org/markwylde/tcpocket.svg)](https://david-dm.org/markwylde/tcpocket) ![GitHub code size in bytes](https://img.shields.io/github/languages/code-size/markwylde/tcpocket) [![GitHub package.json version](https://img.shields.io/github/package-json/v/markwylde/tcpocket)](https://github.com/markwylde/tcpocket/blob/master/package.json) [![GitHub](https://img.shields.io/github/license/markwylde/tcpocket)](https://github.com/markwylde/tcpocket/blob/master/LICENSE)",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Bug fixes:
- client will now queue message until actually conntected
- send will reject if client closes deliberatly
- emitter proxy will now not send errors up the stack

Test coverage:
- increased test coverage 